### PR TITLE
Linked labels

### DIFF
--- a/angular/src/app/app.service.ts
+++ b/angular/src/app/app.service.ts
@@ -322,11 +322,18 @@ export class AppService implements CanActivate {
 
     const relatedKeys = [];
 
-    const s = await this.getSchema(database, table).toPromise();
-    let label: string = s['dj-label'];
+    let label: string;
+    let schema: any;
+    try {
+      schema = await this.getSchema(database, table).toPromise();
+      label = schema['dj-label'];
+    } catch (ex) {
+      // ignore
+    }
+
     if (label) {
 
-      if (loadObject) {
+      if (loadObject && !object) {
         const data = 'dj/' + encodeURIComponent(database) + '/' + encodeURIComponent(table);
         const key = ids.map(id => encodeURIComponent(id)).join('/');
 
@@ -353,7 +360,7 @@ export class AppService implements CanActivate {
           x = x.substring(1);
 
           const res = object[x];
-          const prop = s?.properties[x];
+          const prop = schema?.properties[x];
           const related = prop.ref;
 
           // If the related key is of our ownType,

--- a/angular/src/app/djbase/data.ts
+++ b/angular/src/app/djbase/data.ts
@@ -398,6 +398,7 @@ export class DJDataDashjoin<T> extends DJDataBase<T> {
      * if both are available, make sure to populate the label cache
      */
     private computeLabels() {
+        if (true) return;
         if (this.meta && this.data) {
             try {
                 const t = this.meta.schema as Table;

--- a/angular/src/app/instance/instance.component.ts
+++ b/angular/src/app/instance/instance.component.ts
@@ -8,7 +8,7 @@ import { JsonSchemaFormService } from '@dashjoin/json-schema-form';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { QueryComponent } from '../query/query.component';
 import { AppService } from '../app.service';
-import { forkJoin, Observable } from 'rxjs';
+import { forkJoin, from, Observable, of } from 'rxjs';
 import { Title } from '@angular/platform-browser';
 import { Location } from '@angular/common';
 import { DjEvent } from './dj-event';
@@ -30,6 +30,7 @@ import { Util } from '../util';
 import { Table } from '../model';
 import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
 import { WidgetListComponent } from '../edit-widget-dialog/widgetlist.component';
+import { DJRuntimeService } from '../djruntime.service';
 
 /**
  * main component driving the page layout
@@ -80,6 +81,8 @@ export class InstanceComponent implements OnInit {
    * used for dynamic rendering
    */
   protected componentFactoryResolver: ComponentFactoryResolver;
+
+  protected runtime: DJRuntimeService;
 
   /**
    * inject services
@@ -317,6 +320,7 @@ export class InstanceComponent implements OnInit {
     this.formService = di.get(JsonSchemaFormService);
     this.dialog = di.get(MatDialog);
     this.componentFactoryResolver = di.get(ComponentFactoryResolver);
+    this.runtime = di.get(DJRuntimeService);
   }
 
   /**
@@ -619,7 +623,15 @@ export class InstanceComponent implements OnInit {
    * get the label for a referenced object
    */
   labelId(id: string[]): Observable<string> {
-    return this.app.getIdLabel(id);
+    this.app.setRuntime(this.runtime);
+    return this.app.getIdLabelNG(id);
+    //      return this.app.getIdLabel(id);
+  }
+
+  linkedLabelId(id: string[]): Observable<string> {
+    this.app.setRuntime(this.runtime);
+    return this.app.getIdLabelNG(id, true, this.schema.ID);
+    //      return this.app.getIdLabel(id);
   }
 
   /**

--- a/angular/src/app/widget/links/links.component.html
+++ b/angular/src/app/widget/links/links.component.html
@@ -28,7 +28,7 @@
             <div mat-line *ngFor="let subArray of splitArray(e.value, 3)">
                 <span *ngFor="let e of subArray">
                     <a
-                        [routerLink]="linkArray('/resource/'+e.id.substring(e.id.indexOf('/')+1))">{{labelId(linkArray('/resource/'+e.id.substring(e.id.indexOf('/')+1)))|async}}</a>
+                        [routerLink]="linkArray('/resource/'+e.id.substring(e.id.indexOf('/')+1))">{{linkedLabelId(linkArray('/resource/'+e.id.substring(e.id.indexOf('/')+1)))|async}}</a>
                     &nbsp;
                 </span>
             </div>


### PR DESCRIPTION
These changes directly render the labels of all visible links to other resources, resolving task #37.
This results in a REST call per resource (for resources that are not in the cache yet).
Results are cached and each resource is only called once, so the amount of requests is limited to the linked resources visible on the current page.

Special handling is for M:N relationships such that the label is shown depending from which side (type) being looked at.
I.e. the page for M looks at the M:N and will only display N, and N looking at M:N will see M (this works as intuitively expected).

The new syntax for labels that need dereferencing is to prepend '*'. To render a M:N you could use:
{*M} {*N}
where M and N are attributes (columns) in the relationship (table).
