### PR TITLE
Update CI JDK + caching

### DIFF
--- a/.github/workflows/dashjoin-ci.yml
+++ b/.github/workflows/dashjoin-ci.yml
@@ -14,25 +14,16 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Cache node modules
-      uses: actions/cache@v2
+      uses: c-hive/gha-yarn-cache@v2
       with:
-        path: |
-          **/node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('**/angular/package.json') }}
-
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        directory: angular
 
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '15'
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'maven'
 
     - name: Build with Maven
       run: mvn -B package --file pom-ci.xml -Drevision=1.0.0-$(git rev-parse --short $GITHUB_SHA)


### PR DESCRIPTION
- Switch to Temurin 17 LTS JDK (Adopt no longer maintained)
- Use Java action built-in caching
- Use yarn caching action